### PR TITLE
fix cargo workspace default-features inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ members = [
 imgproc = { version = "0.3.12", path = "imgproc" }
 yuv-sys = { version = "0.3.7", path = "yuv-sys" }
 libwebrtc = { version = "0.3.10", path = "libwebrtc" }
-livekit-api = { version = "0.4.2", path = "livekit-api" }
+livekit-api = { version = "0.4.2", path = "livekit-api", default-features = false }
 livekit-ffi = { version = "0.12.18", path = "livekit-ffi" }
 livekit-protocol = { version = "0.3.9", path = "livekit-protocol" }
-livekit-runtime = { version = "0.4.0", path = "livekit-runtime" }
+livekit-runtime = { version = "0.4.0", path = "livekit-runtime", default-features = false }
 livekit = { version = "0.7.8", path = "livekit" }
 soxr-sys = { version = "0.1.0", path = "soxr-sys" }
 webrtc-sys-build = { version = "0.3.6", path = "webrtc-sys/build" }

--- a/libwebrtc/src/native/mod.rs
+++ b/libwebrtc/src/native/mod.rs
@@ -15,8 +15,8 @@
 #[cfg(target_os = "android")]
 pub mod android;
 pub mod apm;
-pub mod audio_resampler;
 pub mod audio_mixer;
+pub mod audio_resampler;
 pub mod audio_source;
 pub mod audio_stream;
 pub mod audio_track;


### PR DESCRIPTION
I ran into this while fixing up our nix build after the livekit migration.

After making this change I found that mikayla had already fixed it on the zed-patches branch [here](https://github.com/zed-industries/livekit-rust-sdks/commit/1f8eed2e74f0c306bef2e5d62ccb69e79d8ec793).