### PR TITLE
apm: Expose AudioProcessingConfig and AGC2 adaptive digital settings

### DIFF
--- a/examples/local_audio/src/main.rs
+++ b/examples/local_audio/src/main.rs
@@ -43,7 +43,7 @@ impl EchoCancellationProcessor {
         auto_gain_control: bool,
         sample_rate: u32,
     ) -> Self {
-        let apm = AudioProcessingModule::new(
+        let apm = AudioProcessingModule::from_flags(
             echo_cancellation,
             auto_gain_control,
             false, // high_pass_filter - keep disabled for compatibility

--- a/libwebrtc/src/native/apm.rs
+++ b/libwebrtc/src/native/apm.rs
@@ -15,6 +15,10 @@
 use cxx::UniquePtr;
 use webrtc_sys::apm::ffi as sys_apm;
 
+pub use webrtc_sys::apm::ffi::{
+    AdaptiveDigitalConfig, AudioProcessingConfig, GainController2Config,
+};
+
 use crate::{RtcError, RtcErrorType};
 
 pub struct AudioProcessingModule {
@@ -22,22 +26,34 @@ pub struct AudioProcessingModule {
 }
 
 impl AudioProcessingModule {
-    pub fn new(
+    /// Constructs an APM from a full config struct.
+    pub fn new(config: AudioProcessingConfig) -> Self {
+        Self { sys_handle: sys_apm::create_apm(&config) }
+    }
+
+    /// Backward-compatible four-flag constructor.
+    ///
+    /// Each flag toggles only the corresponding component's `.enabled`
+    /// field; every other config value stays at WebRTC's default. In
+    /// particular, `gain_controller_enabled = true` does *not* enable
+    /// AGC2's `adaptive_digital` controller, matching the behavior of
+    /// the previous binding. Use [`AudioProcessingModule::new`] with an
+    /// explicit `AudioProcessingConfig` to opt into adaptive gain.
+    pub fn from_flags(
         echo_canceller_enabled: bool,
         gain_controller_enabled: bool,
         high_pass_filter_enabled: bool,
         noise_suppression_enabled: bool,
     ) -> Self {
-        Self {
-            sys_handle: unsafe {
-                sys_apm::create_apm(
-                    echo_canceller_enabled,
-                    gain_controller_enabled,
-                    high_pass_filter_enabled,
-                    noise_suppression_enabled,
-                )
+        Self::new(AudioProcessingConfig {
+            echo_canceller_enabled,
+            gain_controller2: GainController2Config {
+                enabled: gain_controller_enabled,
+                ..Default::default()
             },
-        }
+            high_pass_filter_enabled,
+            noise_suppression_enabled,
+        })
     }
 
     pub fn process_stream(

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -881,7 +881,7 @@ fn on_new_apm(
     server: &'static FfiServer,
     new_apm: proto::NewApmRequest,
 ) -> FfiResult<proto::NewApmResponse> {
-    let apm = apm::AudioProcessingModule::new(
+    let apm = apm::AudioProcessingModule::from_flags(
         new_apm.echo_canceller_enabled,
         new_apm.gain_controller_enabled,
         new_apm.high_pass_filter_enabled,

--- a/webrtc-sys/include/livekit/apm.h
+++ b/webrtc-sys/include/livekit/apm.h
@@ -23,28 +23,25 @@
 #include "api/video_codecs/video_encoder_factory.h"
 #include "modules/audio_processing/aec3/echo_canceller3.h"
 #include "modules/audio_processing/audio_buffer.h"
+#include "rust/cxx.h"
 
 namespace livekit_ffi {
 
-struct AudioProcessingConfig {
-  bool echo_canceller_enabled;
-  bool gain_controller_enabled;
-  bool high_pass_filter_enabled;
-  bool noise_suppression_enabled;
+// Forward declarations so the cxx-generated header below can reference
+// the C++ class while this header in turn pulls in the cxx-generated
+// definitions of `AudioProcessingConfig` and its nested structs.
+class AudioProcessingModule;
+struct AudioProcessingConfig;
 
-  webrtc::AudioProcessing::Config ToWebrtcConfig() const {
-    webrtc::AudioProcessing::Config config;
-    config.echo_canceller.enabled = echo_canceller_enabled;
-    config.gain_controller2.enabled = gain_controller_enabled;
-    config.high_pass_filter.enabled = high_pass_filter_enabled;
-    config.noise_suppression.enabled = noise_suppression_enabled;
-    return config;
-  }
-};
+}  // namespace livekit_ffi
+
+#include "webrtc-sys/src/apm.rs.h"
+
+namespace livekit_ffi {
 
 class AudioProcessingModule {
  public:
-  AudioProcessingModule(const AudioProcessingConfig& config);
+  explicit AudioProcessingModule(const AudioProcessingConfig& config);
 
   int process_stream(const int16_t* src,
                      size_t src_len,
@@ -67,9 +64,6 @@ class AudioProcessingModule {
 };
 
 std::unique_ptr<AudioProcessingModule> create_apm(
-    bool echo_canceller_enabled,
-    bool gain_controller_enabled,
-    bool high_pass_filter_enabled,
-    bool noise_suppression_enabled);
+    const AudioProcessingConfig& config);
 
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/apm.cpp
+++ b/webrtc-sys/src/apm.cpp
@@ -19,17 +19,46 @@
 #include "api/audio/builtin_audio_processing_builder.h"
 #include "api/environment/environment_factory.h"
 
-#include <iostream>
 #include <memory>
 
 namespace livekit_ffi {
+
+namespace {
+
+webrtc::AudioProcessing::Config ToWebrtcConfig(
+    const AudioProcessingConfig& c) {
+  webrtc::AudioProcessing::Config out;
+  out.echo_canceller.enabled = c.echo_canceller_enabled;
+  out.high_pass_filter.enabled = c.high_pass_filter_enabled;
+  out.noise_suppression.enabled = c.noise_suppression_enabled;
+
+  auto& g = out.gain_controller2;
+  g.enabled = c.gain_controller2.enabled;
+  g.input_volume_controller.enabled =
+      c.gain_controller2.input_volume_controller_enabled;
+  g.fixed_digital.gain_db = c.gain_controller2.fixed_digital_gain_db;
+
+  auto& ad = g.adaptive_digital;
+  ad.enabled = c.gain_controller2.adaptive_digital.enabled;
+  ad.headroom_db = c.gain_controller2.adaptive_digital.headroom_db;
+  ad.max_gain_db = c.gain_controller2.adaptive_digital.max_gain_db;
+  ad.initial_gain_db = c.gain_controller2.adaptive_digital.initial_gain_db;
+  ad.max_gain_change_db_per_second =
+      c.gain_controller2.adaptive_digital.max_gain_change_db_per_second;
+  ad.max_output_noise_level_dbfs =
+      c.gain_controller2.adaptive_digital.max_output_noise_level_dbfs;
+
+  return out;
+}
+
+}  // namespace
 
 AudioProcessingModule::AudioProcessingModule(
     const AudioProcessingConfig& config) {
   apm_ = webrtc::BuiltinAudioProcessingBuilder()
              .Build(webrtc::CreateEnvironment());
 
-  apm_->ApplyConfig(config.ToWebrtcConfig());
+  apm_->ApplyConfig(ToWebrtcConfig(config));
   apm_->Initialize();
 }
 
@@ -58,15 +87,7 @@ int AudioProcessingModule::set_stream_delay_ms(int delay_ms) {
 }
 
 std::unique_ptr<AudioProcessingModule> create_apm(
-    bool echo_canceller_enabled,
-    bool gain_controller_enabled,
-    bool high_pass_filter_enabled,
-    bool noise_suppression_enabled) {
-  AudioProcessingConfig config;
-  config.echo_canceller_enabled = echo_canceller_enabled;
-  config.gain_controller_enabled = gain_controller_enabled;
-  config.high_pass_filter_enabled = high_pass_filter_enabled;
-  config.noise_suppression_enabled = noise_suppression_enabled;
+    const AudioProcessingConfig& config) {
   return std::make_unique<AudioProcessingModule>(config);
 }
 

--- a/webrtc-sys/src/apm.rs
+++ b/webrtc-sys/src/apm.rs
@@ -16,6 +16,35 @@ use crate::impl_thread_safety;
 
 #[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
+    /// Mirrors `webrtc::AudioProcessing::Config::GainController2::AdaptiveDigital`.
+    #[derive(Clone, Copy, Debug)]
+    pub struct AdaptiveDigitalConfig {
+        pub enabled: bool,
+        pub headroom_db: f32,
+        pub max_gain_db: f32,
+        pub initial_gain_db: f32,
+        pub max_gain_change_db_per_second: f32,
+        pub max_output_noise_level_dbfs: f32,
+    }
+
+    /// Mirrors `webrtc::AudioProcessing::Config::GainController2` (AGC2).
+    #[derive(Clone, Copy, Debug)]
+    pub struct GainController2Config {
+        pub enabled: bool,
+        pub input_volume_controller_enabled: bool,
+        pub adaptive_digital: AdaptiveDigitalConfig,
+        pub fixed_digital_gain_db: f32,
+    }
+
+    /// Mirrors `webrtc::AudioProcessing::Config`.
+    #[derive(Clone, Copy, Debug)]
+    pub struct AudioProcessingConfig {
+        pub echo_canceller_enabled: bool,
+        pub gain_controller2: GainController2Config,
+        pub high_pass_filter_enabled: bool,
+        pub noise_suppression_enabled: bool,
+    }
+
     unsafe extern "C++" {
         include!("livekit/apm.h");
 
@@ -43,13 +72,50 @@ pub mod ffi {
 
         fn set_stream_delay_ms(self: Pin<&mut AudioProcessingModule>, delay: i32) -> i32;
 
-        fn create_apm(
-            echo_canceller_enabled: bool,
-            gain_controller_enabled: bool,
-            high_pass_filter_enabled: bool,
-            noise_suppression_enabled: bool,
-        ) -> UniquePtr<AudioProcessingModule>;
+        fn create_apm(config: &AudioProcessingConfig) -> UniquePtr<AudioProcessingModule>;
     }
 }
 
 impl_thread_safety!(ffi::AudioProcessingModule, Send + Sync);
+
+// `Default` lives in this crate because the structs do; downstream crates
+// can't add custom `impl Default` for foreign types due to the orphan rule.
+// The values mirror the field-initializer defaults of
+// `webrtc::AudioProcessing::Config` exactly, so an
+// `AudioProcessingConfig::default()` round-trips through the C++ layer to
+// the same `webrtc::Config` an unconfigured `webrtc::AudioProcessing::Config`
+// would produce.
+impl Default for ffi::AdaptiveDigitalConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            headroom_db: 5.0,
+            max_gain_db: 50.0,
+            initial_gain_db: 15.0,
+            max_gain_change_db_per_second: 6.0,
+            max_output_noise_level_dbfs: -50.0,
+        }
+    }
+}
+
+impl Default for ffi::GainController2Config {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            input_volume_controller_enabled: false,
+            adaptive_digital: ffi::AdaptiveDigitalConfig::default(),
+            fixed_digital_gain_db: 0.0,
+        }
+    }
+}
+
+impl Default for ffi::AudioProcessingConfig {
+    fn default() -> Self {
+        Self {
+            echo_canceller_enabled: false,
+            gain_controller2: ffi::GainController2Config::default(),
+            high_pass_filter_enabled: false,
+            noise_suppression_enabled: false,
+        }
+    }
+}


### PR DESCRIPTION
Replaces the four-bool constructor for `AudioProcessingModule` with a nested config struct that mirrors `webrtc::AudioProcessing::Config`, exposing AGC2's `adaptive_digital` and `fixed_digital` knobs as well as `input_volume_controller`.

With the previous binding, `gain_controller_enabled = true` only flipped `gain_controller2.enabled` and left all sub-controllers at their WebRTC defaults -- in particular `adaptive_digital.enabled = false` and `fixed_digital.gain_db = 0.0f`. The net effect was a no-op limiter on capture with no leveling. This change makes it possible to enable adaptive digital gain (and tune its headroom, max gain, etc.) from Rust without further FFI changes.

The legacy four-bool entry point is preserved as
`AudioProcessingModule::from_flags(...)` so the proto-level `NewApmRequest` handled in `livekit-ffi` keeps its previous behavior verbatim.