### PR TITLE
webrtc-sys: harden RtcError decoding against non-serialized exceptions

### DIFF
--- a/libwebrtc/src/native/peer_connection.rs
+++ b/libwebrtc/src/native/peer_connection.rs
@@ -189,7 +189,7 @@ impl PeerConnection {
 
         match res {
             Ok(_) => Ok(()),
-            Err(e) => unsafe { Err(sys_err::ffi::RtcError::from(e.what()).into()) },
+            Err(e) => Err(sys_err::ffi::RtcError::from(e.what()).into()),
         }
     }
 
@@ -313,7 +313,7 @@ impl PeerConnection {
             Ok(sys_handle) => {
                 Ok(DataChannel { handle: imp_dc::DataChannel::configure(sys_handle) })
             }
-            Err(e) => Err(unsafe { sys_err::ffi::RtcError::from(e.what()).into() }),
+            Err(e) => Err(sys_err::ffi::RtcError::from(e.what()).into()),
         }
     }
 
@@ -327,7 +327,7 @@ impl PeerConnection {
 
         match res {
             Ok(sys_handle) => Ok(RtpSender { handle: imp_rs::RtpSender { sys_handle } }),
-            Err(e) => unsafe { Err(sys_err::ffi::RtcError::from(e.what()).into()) },
+            Err(e) => Err(sys_err::ffi::RtcError::from(e.what()).into()),
         }
     }
 
@@ -340,7 +340,7 @@ impl PeerConnection {
 
         match res {
             Ok(sys_handle) => Ok(RtpTransceiver { handle: imp_rt::RtpTransceiver { sys_handle } }),
-            Err(e) => unsafe { Err(sys_err::ffi::RtcError::from(e.what()).into()) },
+            Err(e) => Err(sys_err::ffi::RtcError::from(e.what()).into()),
         }
     }
 
@@ -355,7 +355,7 @@ impl PeerConnection {
             Ok(cxx_handle) => {
                 Ok(RtpTransceiver { handle: imp_rt::RtpTransceiver { sys_handle: cxx_handle } })
             }
-            Err(e) => unsafe { Err(sys_err::ffi::RtcError::from(e.what()).into()) },
+            Err(e) => Err(sys_err::ffi::RtcError::from(e.what()).into()),
         }
     }
 
@@ -404,7 +404,7 @@ impl PeerConnection {
     pub fn remove_track(&self, sender: RtpSender) -> Result<(), RtcError> {
         self.sys_handle
             .remove_track(sender.handle.sys_handle)
-            .map_err(|e| unsafe { sys_err::ffi::RtcError::from(e.what()).into() })
+            .map_err(|e| sys_err::ffi::RtcError::from(e.what()).into())
     }
 
     pub async fn get_stats(&self) -> Result<Vec<RtcStats>, RtcError> {

--- a/libwebrtc/src/native/peer_connection_factory.rs
+++ b/libwebrtc/src/native/peer_connection_factory.rs
@@ -70,7 +70,7 @@ impl PeerConnectionFactory {
             Ok(sys_handle) => Ok(PeerConnection {
                 handle: imp_pc::PeerConnection::configure(sys_handle, observer),
             }),
-            Err(e) => Err(unsafe { sys_err::ffi::RtcError::from(e.what()).into() }),
+            Err(e) => Err(sys_err::ffi::RtcError::from(e.what()).into()),
         }
     }
 

--- a/libwebrtc/src/native/rtp_sender.rs
+++ b/libwebrtc/src/native/rtp_sender.rs
@@ -78,6 +78,6 @@ impl RtpSender {
     pub fn set_parameters(&self, parameters: RtpParameters) -> Result<(), RtcError> {
         self.sys_handle
             .set_parameters(parameters.into())
-            .map_err(|e| unsafe { sys_err::ffi::RtcError::from(e.what()).into() })
+            .map_err(|e| sys_err::ffi::RtcError::from(e.what()).into())
     }
 }

--- a/libwebrtc/src/native/rtp_transceiver.rs
+++ b/libwebrtc/src/native/rtp_transceiver.rs
@@ -87,12 +87,10 @@ impl RtpTransceiver {
     pub fn set_codec_preferences(&self, codecs: Vec<RtpCodecCapability>) -> Result<(), RtcError> {
         self.sys_handle
             .set_codec_preferences(codecs.into_iter().map(Into::into).collect())
-            .map_err(|e| unsafe { sys_err::ffi::RtcError::from(e.what()).into() })
+            .map_err(|e| sys_err::ffi::RtcError::from(e.what()).into())
     }
 
     pub fn stop(&self) -> Result<(), RtcError> {
-        self.sys_handle
-            .stop_standard()
-            .map_err(|e| unsafe { sys_err::ffi::RtcError::from(e.what()).into() })
+        self.sys_handle.stop_standard().map_err(|e| sys_err::ffi::RtcError::from(e.what()).into())
     }
 }

--- a/webrtc-sys/src/rtc_error.rs
+++ b/webrtc-sys/src/rtc_error.rs
@@ -64,28 +64,75 @@ pub mod ffi {
 }
 
 impl ffi::RtcError {
-    /// # Safety
-    /// The value must be correctly encoded
-    pub unsafe fn from(value: &str) -> Self {
-        // Parse the hex encoded error from c++
-        let error_type = u32::from_str_radix(&value[0..8], 16).unwrap();
-        let error_detail = u32::from_str_radix(&value[8..16], 16).unwrap();
-        let has_scp_cause_code = u8::from_str_radix(&value[16..18], 16).unwrap();
-        let sctp_cause_code = u16::from_str_radix(&value[18..22], 16).unwrap();
-        let message = String::from(&value[22..]); // msg isn't encoded
+    /// Decodes the hex-encoded error produced by the C++ `serialize_error`.
+    ///
+    /// `value` is the `what()` string of a [`cxx::Exception`], which may carry any
+    /// exception that crossed the FFI boundary, not only our serialized errors. When
+    /// `value` is not in the expected format it is surfaced as an [`InternalError`]
+    /// carrying the raw message instead of panicking.
+    ///
+    /// [`InternalError`]: ffi::RtcErrorType::InternalError
+    pub fn from(value: &str) -> Self {
+        Self::parse(value).unwrap_or_else(|| Self {
+            error_type: ffi::RtcErrorType::InternalError,
+            error_detail: ffi::RtcErrorDetailType::None,
+            has_sctp_cause_code: false,
+            sctp_cause_code: 0,
+            message: value.to_string(),
+        })
+    }
 
-        Self {
-            error_type: std::mem::transmute(error_type),
-            error_detail: std::mem::transmute(error_detail),
+    fn parse(value: &str) -> Option<Self> {
+        let error_type = u32::from_str_radix(value.get(0..8)?, 16).ok()?;
+        let error_detail = u32::from_str_radix(value.get(8..16)?, 16).ok()?;
+        let has_sctp_cause_code = u8::from_str_radix(value.get(16..18)?, 16).ok()?;
+        let sctp_cause_code = u16::from_str_radix(value.get(18..22)?, 16).ok()?;
+        let message = value.get(22..)?; // msg isn't encoded
+
+        Some(Self {
+            error_type: error_type_from_repr(error_type)?,
+            error_detail: error_detail_from_repr(error_detail)?,
             sctp_cause_code,
-            has_sctp_cause_code: has_scp_cause_code == 1,
-            message,
-        }
+            has_sctp_cause_code: has_sctp_cause_code == 1,
+            message: message.to_string(),
+        })
     }
 
     pub fn ok(&self) -> bool {
         self.error_type == ffi::RtcErrorType::None
     }
+}
+
+fn error_type_from_repr(value: u32) -> Option<ffi::RtcErrorType> {
+    Some(match value {
+        0 => ffi::RtcErrorType::None,
+        1 => ffi::RtcErrorType::UnsupportedOperation,
+        2 => ffi::RtcErrorType::UnsupportedParameter,
+        3 => ffi::RtcErrorType::InvalidParameter,
+        4 => ffi::RtcErrorType::InvalidRange,
+        5 => ffi::RtcErrorType::SyntaxError,
+        6 => ffi::RtcErrorType::InvalidState,
+        7 => ffi::RtcErrorType::InvalidModification,
+        8 => ffi::RtcErrorType::NetworkError,
+        9 => ffi::RtcErrorType::ResourceExhausted,
+        10 => ffi::RtcErrorType::InternalError,
+        11 => ffi::RtcErrorType::OperationErrorWithData,
+        _ => return None,
+    })
+}
+
+fn error_detail_from_repr(value: u32) -> Option<ffi::RtcErrorDetailType> {
+    Some(match value {
+        0 => ffi::RtcErrorDetailType::None,
+        1 => ffi::RtcErrorDetailType::DataChannelFailure,
+        2 => ffi::RtcErrorDetailType::DtlsFailure,
+        3 => ffi::RtcErrorDetailType::FingerprintFailure,
+        4 => ffi::RtcErrorDetailType::SctpFailure,
+        5 => ffi::RtcErrorDetailType::SdpSyntaxError,
+        6 => ffi::RtcErrorDetailType::HardwareEncoderNotAvailable,
+        7 => ffi::RtcErrorDetailType::HardwareEncoderError,
+        _ => return None,
+    })
 }
 
 impl Error for ffi::RtcError {}
@@ -113,7 +160,7 @@ mod tests {
     #[test]
     fn serialize_deserialize() {
         let str = ffi::serialize_deserialize();
-        let error = unsafe { RtcError::from(&str) };
+        let error = RtcError::from(&str);
 
         assert_eq!(error.error_type, RtcErrorType::InternalError);
         assert_eq!(error.error_detail, RtcErrorDetailType::DataChannelFailure);
@@ -125,7 +172,7 @@ mod tests {
     #[test]
     fn throw_error() {
         let exc: cxx::Exception = ffi::throw_error().err().unwrap();
-        let error = unsafe { RtcError::from(exc.what()) };
+        let error = RtcError::from(exc.what());
 
         assert_eq!(error.error_type, RtcErrorType::InvalidModification);
         assert_eq!(error.error_detail, RtcErrorDetailType::None);


### PR DESCRIPTION
We observed unwrap panics in RtcError::from when decoding the hex-encoded
error string from C++.

Investigation: the decoded value is cxx::Exception::what(), which surfaces
*any* std::exception that crosses the FFI boundary, not only the errors our
C++ produces via serialize_error(). Our own throw sites in peer_connection.cpp
write a well-formed 8+8+2+4 hex prefix followed by the raw message, but a
non-serialized exception (e.g. std::bad_alloc or a runtime_error from deeper
WebRTC code) arrives as plain text. Feeding that to from_str_radix(...).unwrap()
panics, and an empty/short what() would even panic on the slice indexing. A
secondary hazard: std::mem::transmute of the parsed u32 into the repr(i32) enum
is UB whenever the value falls outside the valid variant range.

Fix: make RtcError::from total and safe.
- Replace from_str_radix().unwrap() with value.get(range)? + .ok()?, so
  malformed or too-short input returns None instead of panicking.
- Replace transmute with explicit u32 -> enum mappings that reject unknown
  discriminants.
- On any parse failure, fall back to RtcErrorType::InternalError carrying the
  raw message, which is more debuggable than a crash.
- Drop the now-unneeded unsafe from the function and all call sites.