### PR TITLE
changes forward declaration of PeerContext to a struct from a class

### DIFF
--- a/webrtc-sys/include/livekit/jsep.h
+++ b/webrtc-sys/include/livekit/jsep.h
@@ -35,7 +35,7 @@ class SessionDescription;
 
 namespace livekit_ffi {
 
-class PeerContext;
+struct PeerContext;
 
 class IceCandidate {
  public:


### PR DESCRIPTION
Zed fails to build on windows because `PeerContext` is forward-declared as a class in [include/livekit/jsep.h](https://github.com/zed-industries/livekit-rust-sdks/blob/main/webrtc-sys/include/livekit/jsep.h) instead of a struct. This results in LNK2019 errors due to inconsistent name mangling. 

This fix was also applied to the official [livekit/rust-sdks](https://github.com/livekit/rust-sdks) in 0caf9f522f343f5cfdbc5e5e0f62d1c8b2792fa1